### PR TITLE
Add Apple Container training workflow

### DIFF
--- a/apple/Dockerfile
+++ b/apple/Dockerfile
@@ -2,9 +2,8 @@ FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Configura DNS e mirrors compatíveis com o builder do Apple Container
-RUN printf 'nameserver 8.8.8.8\nnameserver 1.1.1.1\n' > /etc/resolv.conf \
-    && sed -i 's|http://ports.ubuntu.com/ubuntu-ports|http://archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list
+# Ajusta mirrors para evitar indisponibilidade do domínio ports.ubuntu.com
+RUN sed -i 's|http://ports.ubuntu.com/ubuntu-ports|http://archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list
 
 # Instala dependências básicas e fontes utilizadas pelo PEC
 RUN apt-get update && apt-get install -y \

--- a/apple/Dockerfile
+++ b/apple/Dockerfile
@@ -1,0 +1,80 @@
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Configura DNS e mirrors compatíveis com o builder do Apple Container
+RUN printf 'nameserver 8.8.8.8\nnameserver 1.1.1.1\n' > /etc/resolv.conf \
+    && sed -i 's|http://ports.ubuntu.com/ubuntu-ports|http://archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list
+
+# Instala dependências básicas e fontes utilizadas pelo PEC
+RUN apt-get update && apt-get install -y \
+    locales \
+    && locale-gen "pt_BR.UTF-8" \
+    && dpkg-reconfigure --frontend=noninteractive locales \
+    && apt-get install -y \
+    coreutils wget apt-utils gnupg2 software-properties-common file libfreetype6 ntp ttf-mscorefonts-installer fontconfig
+
+RUN fc-cache -fv && chmod -R 777 /usr/share/fonts/truetype/msttcorefonts
+
+# Instala Amazon Corretto 17
+RUN wget -O - https://apt.corretto.aws/corretto.key | gpg --dearmor -o /usr/share/keyrings/corretto-keyring.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/corretto-keyring.gpg] https://apt.corretto.aws stable main" | tee /etc/apt/sources.list.d/corretto.list \
+    && apt-get update && apt-get install -y java-17-amazon-corretto-jdk
+
+# Instalações para systemd e demais utilitários necessários
+RUN sed -i 's/# deb/deb/g' /etc/apt/sources.list \
+    && apt-get update && apt-get install --no-install-recommends -y \
+       dbus systemd systemd-cron rsyslog iproute2 python-is-python3 python3 python3-apt sudo bash ca-certificates \
+    && apt-get clean \
+    && rm -rf /usr/share/doc/* /usr/share/man/* /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Cliente PostgreSQL para execução dos scripts de treinamento
+RUN apt-get update && apt-get install -y postgresql-client
+
+# Substitui ps/systemctl para execução em ambientes sem systemd real
+RUN mv /bin/ps /bin/ps.original \
+    && { \
+      echo '#!/bin/sh'; \
+      echo 'if [ "$1" = "--no-headers" ] && [ "$2" = "-o" ] && [ "$3" = "comm" ] && [ "$4" = "1" ]; then'; \
+      echo '  echo "systemd (simulated: ps $@)"'; \
+      echo 'else'; \
+      echo '  /bin/ps.original "$@"'; \
+      echo 'fi'; \
+    } > /bin/ps \
+    && chmod +x /bin/ps
+
+RUN { \
+      echo '#!/bin/sh'; \
+      echo 'echo "Simulated systemctl command: $0 $@"'; \
+      echo 'case "$1" in'; \
+      echo '  start|stop|restart|status) exit 0 ;;'; \
+      echo '  *) echo "Simulated systemctl: $@"; exit 0 ;;'; \
+      echo 'esac'; \
+    } > /bin/systemctl \
+    && chmod +x /bin/systemctl
+
+ARG JAR_FILENAME
+ARG HTTPS_DOMAIN
+ARG DB_URL
+ARG POSTGRES_PASS
+ARG POSTGRES_USER
+ARG TRAINING
+
+ENV JAR_FILENAME=${JAR_FILENAME} \
+    TRAINING=${TRAINING} \
+    DB_URL=${DB_URL} \
+    POSTGRES_PASS=${POSTGRES_PASS} \
+    POSTGRES_USER=${POSTGRES_USER} \
+    HTTPS_DOMAIN=${HTTPS_DOMAIN}
+
+RUN mkdir -p /opt/e-SUS/webserver/chaves /backups /var/www/html
+WORKDIR /var/www/html
+
+COPY ./${JAR_FILENAME} ${JAR_FILENAME}
+COPY ./install.sh ./install.sh
+COPY backups/ /backups/
+COPY apple/entrypoint.sh /entrypoint.sh
+
+RUN chmod +x /entrypoint.sh ./install.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/apple/Dockerfile
+++ b/apple/Dockerfile
@@ -1,56 +1,4 @@
-FROM ubuntu:22.04
-
-ENV DEBIAN_FRONTEND=noninteractive
-
-# Ajusta mirrors para evitar indisponibilidade do domínio ports.ubuntu.com
-RUN sed -i 's|http://ports.ubuntu.com/ubuntu-ports|http://archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list
-
-# Instala dependências básicas e fontes utilizadas pelo PEC
-RUN apt-get update && apt-get install -y \
-    locales \
-    && locale-gen "pt_BR.UTF-8" \
-    && dpkg-reconfigure --frontend=noninteractive locales \
-    && apt-get install -y \
-    coreutils wget apt-utils gnupg2 software-properties-common file libfreetype6 ntp ttf-mscorefonts-installer fontconfig
-
-RUN fc-cache -fv && chmod -R 777 /usr/share/fonts/truetype/msttcorefonts
-
-# Instala Amazon Corretto 17
-RUN wget -O - https://apt.corretto.aws/corretto.key | gpg --dearmor -o /usr/share/keyrings/corretto-keyring.gpg \
-    && echo "deb [signed-by=/usr/share/keyrings/corretto-keyring.gpg] https://apt.corretto.aws stable main" | tee /etc/apt/sources.list.d/corretto.list \
-    && apt-get update && apt-get install -y java-17-amazon-corretto-jdk
-
-# Instalações para systemd e demais utilitários necessários
-RUN sed -i 's/# deb/deb/g' /etc/apt/sources.list \
-    && apt-get update && apt-get install --no-install-recommends -y \
-       dbus systemd systemd-cron rsyslog iproute2 python-is-python3 python3 python3-apt sudo bash ca-certificates \
-    && apt-get clean \
-    && rm -rf /usr/share/doc/* /usr/share/man/* /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-# Cliente PostgreSQL para execução dos scripts de treinamento
-RUN apt-get update && apt-get install -y postgresql-client
-
-# Substitui ps/systemctl para execução em ambientes sem systemd real
-RUN mv /bin/ps /bin/ps.original \
-    && { \
-      echo '#!/bin/sh'; \
-      echo 'if [ "$1" = "--no-headers" ] && [ "$2" = "-o" ] && [ "$3" = "comm" ] && [ "$4" = "1" ]; then'; \
-      echo '  echo "systemd (simulated: ps $@)"'; \
-      echo 'else'; \
-      echo '  /bin/ps.original "$@"'; \
-      echo 'fi'; \
-    } > /bin/ps \
-    && chmod +x /bin/ps
-
-RUN { \
-      echo '#!/bin/sh'; \
-      echo 'echo "Simulated systemctl command: $0 $@"'; \
-      echo 'case "$1" in'; \
-      echo '  start|stop|restart|status) exit 0 ;;'; \
-      echo '  *) echo "Simulated systemctl: $@"; exit 0 ;;'; \
-      echo 'esac'; \
-    } > /bin/systemctl \
-    && chmod +x /bin/systemctl
+FROM amazoncorretto:17
 
 ARG JAR_FILENAME
 ARG HTTPS_DOMAIN
@@ -59,7 +7,10 @@ ARG POSTGRES_PASS
 ARG POSTGRES_USER
 ARG TRAINING
 
-ENV JAR_FILENAME=${JAR_FILENAME} \
+ENV LANG=pt_BR.UTF-8 \
+    LANGUAGE=pt_BR:pt \
+    LC_ALL=pt_BR.UTF-8 \
+    JAR_FILENAME=${JAR_FILENAME} \
     TRAINING=${TRAINING} \
     DB_URL=${DB_URL} \
     POSTGRES_PASS=${POSTGRES_PASS} \
@@ -69,9 +20,9 @@ ENV JAR_FILENAME=${JAR_FILENAME} \
 RUN mkdir -p /opt/e-SUS/webserver/chaves /backups /var/www/html
 WORKDIR /var/www/html
 
-COPY ./${JAR_FILENAME} ${JAR_FILENAME}
 COPY ./install.sh ./install.sh
-COPY backups/ /backups/
+COPY ./backups/ /backups/
+COPY ./${JAR_FILENAME} ${JAR_FILENAME}
 COPY apple/entrypoint.sh /entrypoint.sh
 
 RUN chmod +x /entrypoint.sh ./install.sh

--- a/apple/apple-container-composer.sh
+++ b/apple/apple-container-composer.sh
@@ -1,0 +1,191 @@
+#!/bin/bash
+
+set -euo pipefail
+
+REQUIRED_COMMANDS=(container curl jq)
+
+check_dependencies() {
+  local missing=()
+  for cmd in "${REQUIRED_COMMANDS[@]}"; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+      missing+=("$cmd")
+    fi
+  done
+
+  if [ ${#missing[@]} -ne 0 ]; then
+    echo "Dependências ausentes: ${missing[*]}" >&2
+    exit 1
+  fi
+}
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$PROJECT_ROOT"
+
+create_env_file_if_needed() {
+  if [ ! -f .env ]; then
+    if [ -f .env.example ]; then
+      cp .env.example .env
+      echo "Arquivo .env criado a partir de .env.example. Edite se necessário."
+    else
+      echo "Arquivo .env não encontrado e .env.example indisponível."
+      exit 1
+    fi
+  fi
+}
+
+strip_quotes() {
+  local value="$1"
+  value="${value%\'}"
+  value="${value%\"}"
+  value="${value#\'}"
+  value="${value#\"}"
+  printf '%s' "$value"
+}
+
+load_env() {
+  set -o allexport
+  # shellcheck disable=SC2046
+  source <(grep -v '^#' .env | sed '/^[[:space:]]*$/d')
+  set +o allexport
+
+  POSTGRES_DB=$(strip_quotes "${POSTGRES_DB:-esus}")
+  POSTGRES_USER=$(strip_quotes "${POSTGRES_USER:-postgres}")
+  POSTGRES_PASS=$(strip_quotes "${POSTGRES_PASS:-pass}")
+  POSTGRES_HOST=$(strip_quotes "${POSTGRES_HOST:-db}")
+  POSTGRES_PORT=$(strip_quotes "${POSTGRES_PORT:-5432}")
+  HTTPS_DOMAIN=$(strip_quotes "${HTTPS_DOMAIN:-}")
+  TZ=$(strip_quotes "${TZ:-America/Sao_Paulo}")
+  FILENAME=$(strip_quotes "${FILENAME:-}")
+}
+
+determine_jar() {
+  if [ -z "$FILENAME" ]; then
+    echo "Buscando link do instalador mais recente..."
+    local endpoint="https://n8n.adri.orango.io/webhook/b1b09703-6eff-42cc-a2a2-8affd46debd3"
+    local response
+    if ! response=$(curl -fsSL "$endpoint"); then
+      echo "Não foi possível obter o link do instalador." >&2
+      exit 1
+    fi
+    FILENAME=$(printf '%s' "$response" | jq -r '.link_linux')
+    if [ -z "$FILENAME" ] || [ "$FILENAME" = "null" ]; then
+      echo "Resposta inválida ao buscar link do instalador." >&2
+      exit 1
+    fi
+  fi
+
+  if echo "$FILENAME" | grep -Eq '^https?://'; then
+    JAR_FILENAME=$(basename "$FILENAME")
+    if [ ! -f "$JAR_FILENAME" ]; then
+      echo "Baixando $JAR_FILENAME..."
+      curl -fsSL "$FILENAME" -o "$JAR_FILENAME"
+    else
+      echo "Arquivo $JAR_FILENAME já disponível, reutilizando download."
+    fi
+  else
+    if [ ! -f "$FILENAME" ]; then
+      echo "Arquivo informado em FILENAME não encontrado: $FILENAME" >&2
+      exit 1
+    fi
+    JAR_FILENAME=$(basename "$FILENAME")
+    if [ "$FILENAME" != "$JAR_FILENAME" ]; then
+      cp "$FILENAME" "$JAR_FILENAME"
+    fi
+  fi
+}
+
+prepare_volumes() {
+  mkdir -p esus-data/db esus-data/opt esus-data/backups
+}
+
+cleanup_existing_container() {
+  local name="$1"
+  if container inspect "$name" >/dev/null 2>&1; then
+    container stop "$name" >/dev/null 2>&1 || true
+    container delete "$name" >/dev/null 2>&1 || true
+  fi
+}
+
+build_image() {
+  local image_name="$1"
+  local jdbc_url="jdbc:postgresql://db:${POSTGRES_PORT}/${POSTGRES_DB}"
+  local build_args=(
+    "--tag" "$image_name"
+    "--file" "apple/Dockerfile"
+    "--build-arg" "JAR_FILENAME=$JAR_FILENAME"
+    "--build-arg" "HTTPS_DOMAIN=$HTTPS_DOMAIN"
+    "--build-arg" "DB_URL=$jdbc_url"
+    "--build-arg" "POSTGRES_USER=$POSTGRES_USER"
+    "--build-arg" "POSTGRES_PASS=$POSTGRES_PASS"
+    "--build-arg" "TRAINING=true"
+  )
+  echo "Construindo imagem $image_name..."
+  container build "${build_args[@]}" .
+}
+
+create_runtime_env_file() {
+  RUNTIME_ENV_FILE=$(mktemp)
+  cat > "$RUNTIME_ENV_FILE" <<EOF_ENV
+POSTGRES_DB=$POSTGRES_DB
+POSTGRES_USER=$POSTGRES_USER
+POSTGRES_PASS=$POSTGRES_PASS
+POSTGRES_HOST=db
+POSTGRES_PORT=$POSTGRES_PORT
+HTTPS_DOMAIN=$HTTPS_DOMAIN
+TZ=$TZ
+TRAINING=true
+EOF_ENV
+}
+
+start_database() {
+  echo "Iniciando banco de dados..."
+  container run --name db --detach \
+    --env POSTGRES_USER="$POSTGRES_USER" \
+    --env POSTGRES_PASSWORD="$POSTGRES_PASS" \
+    --env POSTGRES_DB="$POSTGRES_DB" \
+    --volume "$(pwd)/esus-data/db:/var/lib/postgresql/data" \
+    postgres:9.6-alpine >/dev/null
+}
+
+start_pec() {
+  local image_name="$1"
+  echo "Iniciando PEC em modo treinamento..."
+  container run --name pec --detach \
+    --volume "$(pwd)/esus-data/opt:/opt/e-SUS" \
+    --volume "$(pwd)/esus-data/backups:/backups" \
+    --volume /sys/fs/cgroup:/sys/fs/cgroup:ro \
+    --env-file "$RUNTIME_ENV_FILE" \
+    --publish 8080:8080 \
+    --publish 80:80 \
+    --publish 443:443 \
+    "$image_name" >/dev/null
+}
+
+main() {
+  check_dependencies
+  create_env_file_if_needed
+  load_env
+  determine_jar
+  prepare_volumes
+
+  echo "Iniciando serviço Apple Container..."
+  container system start
+
+  local image_name="pec-training"
+  build_image "$image_name"
+
+  cleanup_existing_container pec
+  cleanup_existing_container db
+
+  create_runtime_env_file
+  trap 'rm -f "$RUNTIME_ENV_FILE"' EXIT
+
+  start_database
+  echo "Aguardando inicialização do banco..."
+  sleep 10
+  start_pec "$image_name"
+
+  echo "Containers iniciados. Acesse http://localhost:8080"
+}
+
+main "$@"

--- a/apple/apple-container-composer.sh
+++ b/apple/apple-container-composer.sh
@@ -150,15 +150,28 @@ start_database() {
 start_pec() {
   local image_name="$1"
   echo "Iniciando PEC em modo treinamento..."
-  container run --name pec --detach \
-    --volume "$(pwd)/esus-data/opt:/opt/e-SUS" \
-    --volume "$(pwd)/esus-data/backups:/backups" \
-    --volume /sys/fs/cgroup:/sys/fs/cgroup:ro \
-    --env-file "$RUNTIME_ENV_FILE" \
-    --publish 8080:8080 \
-    --publish 80:80 \
-    --publish 443:443 \
-    "$image_name" >/dev/null
+  local run_args=(
+    --name pec
+    --detach
+    --volume "$(pwd)/esus-data/opt:/opt/e-SUS"
+    --volume "$(pwd)/esus-data/backups:/backups"
+  )
+
+  if [ -d /sys/fs/cgroup ]; then
+    run_args+=(--volume /sys/fs/cgroup:/sys/fs/cgroup:ro)
+  else
+    echo "Aviso: /sys/fs/cgroup não encontrado no host; prosseguindo sem montar cgroups." >&2
+  fi
+
+  run_args+=(
+    --env-file "$RUNTIME_ENV_FILE"
+    --publish 8080:8080
+    --publish 80:80
+    --publish 443:443
+    "$image_name"
+  )
+
+  container run "${run_args[@]}" >/dev/null
 }
 
 main() {

--- a/apple/entrypoint.sh
+++ b/apple/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 
 : '
@@ -28,7 +28,7 @@ fi
 if [ -f "/etc/pec.config" ]; then
   config=$(cat /etc/pec.config)
 
-  if echo "$config" | grep -q "\"success\" : true"; then
+  if printf '%s' "$config" | grep -q '"success" : true'; then
     echo ">> Iniciando aplicação principal..."
     exec /opt/e-SUS/webserver/standalone.sh
   else

--- a/apple/entrypoint.sh
+++ b/apple/entrypoint.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -e
+
+: '
+{
+  "success" : true,
+  "directory" : "/opt/e-SUS",
+  "version" : "5.3.19",
+  "production" : true,
+  "customDatabase" : true,
+  "databaseUrl" : "jdbc:postgresql://db:5432/esus",
+  "databaseUsername" : "postgres",
+  "databasePassword" : "pass",
+  "jreVersion" : "17.0.10-linux_x64",
+  "jreDirectory" : "/opt/e-SUS/jre/17.0.10-linux_x64",
+  "webserverVersion" : "5.3.19",
+  "webserverDirectory" : "/opt/e-SUS/webserver"
+}
+'
+
+if [ ! -f /etc/pec.config ]; then
+    echo ">> Sistema ainda não foi instalado. Instalando..."
+    echo ">> Gerando certificado com CertMgr e instalando o sistema..."
+    chmod +x ./install.sh
+    ./install.sh
+fi
+
+if [ -f "/etc/pec.config" ]; then
+  config=$(cat /etc/pec.config)
+
+  if echo "$config" | grep -q "\"success\" : true"; then
+    echo ">> Iniciando aplicação principal..."
+    exec /opt/e-SUS/webserver/standalone.sh
+  else
+    echo ">> Erro: Instalação não foi bem-sucedida."
+    echo ">> Tentando reinstalar sistema..."
+    chmod +x ./install.sh
+    ./install.sh
+    exit 1
+  fi
+fi
+
+echo ">> Iniciando aplicação principal..."
+exec /opt/e-SUS/webserver/standalone.sh

--- a/install.sh
+++ b/install.sh
@@ -16,7 +16,7 @@ echo "Variáveis de ambiente:"
 echo "*******************"
 echo "HTTPS_DOMAIN: ${HTTPS_DOMAIN}"
 echo "DB_URL: ${DB_URL}"
-echo "POSTGRES_USER: ${POSTGRES_USER}"  
+echo "POSTGRES_USER: ${POSTGRES_USER}"
 echo "POSTGRES_PASS: ${POSTGRES_PASS}"
 echo "JAR_FILENAME: ${JAR_FILENAME}"
 echo "TRAINING: ${TRAINING}"
@@ -30,14 +30,14 @@ fi
 
 # Verificando variáveis de banco de dados
 if [ -n "$DB_URL" ]; then
-  ARGS="$ARGS -url=${DB_URL}" 
+  ARGS="$ARGS -url=${DB_URL}"
 fi
 
 if [ -n "$POSTGRES_USER" ]; then
   ARGS="$ARGS -username=${POSTGRES_USER}"
 fi
 
-if [ -n "$POSTGRES_PASS" ]; then  
+if [ -n "$POSTGRES_PASS" ]; then
   ARGS="$ARGS -password=${POSTGRES_PASS}"
 fi
 
@@ -52,20 +52,23 @@ java -jar ${JAR_FILENAME} -console ${ARGS} -continue
 
 # Verificando se a variável de treinamento existe, caso sim, executa o SQL
 if [ -n "$TRAINING" ]; then
-  echo -e "${GREEN}Treinamento habilitado. Executando SQL de configuração...${NC}"
-  PSQL_CMD="psql -h ${POSTGRES_HOST} -p ${POSTGRES_PORT} -U ${POSTGRES_USER} -d ${POSTGRES_DB} -c \"update tb_config_sistema set ds_texto = null, ds_inteiro = 1 where co_config_sistema = 'TREINAMENTO';\""
-  
-  # Exporta a senha do banco para evitar o prompt
-  export PGPASSWORD="${POSTGRES_PASS}"
+  if command -v psql >/dev/null 2>&1; then
+    echo -e "${GREEN}Treinamento habilitado. Executando SQL de configuração...${NC}"
+    PSQL_CMD="psql -h ${POSTGRES_HOST} -p ${POSTGRES_PORT} -U ${POSTGRES_USER} -d ${POSTGRES_DB} -c \"update tb_config_sistema set ds_texto = null, ds_inteiro = 1 where co_config_sistema = 'TREINAMENTO';\""
 
-  # Executa o comando SQL
-  eval $PSQL_CMD
-  if [ $? -eq 0 ]; then
-    echo -e "${GREEN}Configuração de treinamento aplicada com sucesso.${NC}"
+    # Exporta a senha do banco para evitar o prompt
+    export PGPASSWORD="${POSTGRES_PASS}"
+
+    # Executa o comando SQL
+    if eval "$PSQL_CMD"; then
+      echo -e "${GREEN}Configuração de treinamento aplicada com sucesso.${NC}"
+    else
+      echo -e "${RED}Erro ao aplicar configuração de treinamento.${NC}"
+    fi
+
+    # Limpa a variável de senha para segurança
+    unset PGPASSWORD
   else
-    echo -e "${RED}Erro ao aplicar configuração de treinamento.${NC}"
+    echo -e "${RED}psql não encontrado. Pule a configuração de treinamento ou instale o cliente PostgreSQL.${NC}"
   fi
-
-  # Limpa a variável de senha para segurança
-  unset PGPASSWORD
 fi


### PR DESCRIPTION
## Summary
- add an Apple Container helper script that provisions the training environment
- include a dedicated Dockerfile and entrypoint tailored for the Apple builder
- add a backups directory placeholder consumed during image builds

## Testing
- bash -n apple/apple-container-composer.sh

------
https://chatgpt.com/codex/tasks/task_e_68fa94046b7483219a3d2269355ff20a